### PR TITLE
feat(CAS-169): add block-sensitive-paths composite action

### DIFF
--- a/block-sensitive-paths/README.md
+++ b/block-sensitive-paths/README.md
@@ -1,0 +1,68 @@
+# block-sensitive-paths
+
+A reusable GitHub Actions composite action that **rejects pull requests** containing
+files in private/internal directories that must not appear in public repositories.
+
+## Features
+
+- Configurable list of blocked path patterns (directory prefixes and exact filenames)
+- Runs on PR events; fails the check with a clear message listing each blocked file
+- Handles large PRs via paginated GitHub API calls
+- Emits per-file `::error::` annotations so violations are highlighted in the PR diff
+- Zero external dependencies — pure bash + `gh` CLI (available on all GitHub-hosted runners)
+
+## Usage
+
+```yaml
+name: PR Path Guard
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  block-sensitive-paths:
+    name: Block sensitive paths
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block sensitive paths
+        uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Custom blocked paths
+
+```yaml
+      - name: Block sensitive paths
+        uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@main
+        with:
+          blocked-paths: |
+            .ai/
+            docs/plans/
+            artifacts/
+            internal/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `blocked-paths` | No | `.ai/` `docs/plans/` `artifacts/` | Newline-separated path patterns. Trailing `/` matches a directory prefix; no trailing `/` matches an exact filename. |
+| `github-token` | No | `${{ github.token }}` | Token for the GitHub REST API to list PR files. |
+
+## Branch protection setup
+
+After enabling the action in a repo, add `Block sensitive paths` as a required status
+check in **Settings → Branches → Branch protection rules** to prevent merging blocked PRs.
+
+## Pattern matching rules
+
+- `".ai/"` — matches any file whose path starts with `.ai/` (e.g. `.ai/steering/foo.md`)
+- `"docs/plans/"` — matches any file under `docs/plans/`
+- `"secret.txt"` — exact filename match only

--- a/block-sensitive-paths/action.yml
+++ b/block-sensitive-paths/action.yml
@@ -1,0 +1,107 @@
+name: 'Block Sensitive Paths'
+description: >
+  Rejects pull requests that touch private/internal directories that must not
+  appear in public repositories. Runs on PR events and fails the check with a
+  clear error listing the offending files and the reason they are blocked.
+author: 'CascadeGuard'
+branding:
+  icon: 'shield'
+  color: 'red'
+
+inputs:
+  blocked-paths:
+    description: |
+      Newline-separated list of path prefixes to block.
+      A trailing slash (e.g. ".ai/") matches any file inside that directory.
+      An exact string without a trailing slash matches only that specific file.
+    required: false
+    default: |
+      .ai/
+      docs/plans/
+      artifacts/
+  github-token:
+    description: >
+      GitHub token used to list PR changed files via the REST API.
+      Defaults to the built-in GITHUB_TOKEN.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check for sensitive paths
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_BLOCKED_PATHS: ${{ inputs.blocked-paths }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # Parse blocked path patterns — strip blank lines and # comments
+        mapfile -t BLOCKED < <(
+          printf '%s\n' "$INPUT_BLOCKED_PATHS" \
+            | grep -v '^\s*#' \
+            | grep -v '^\s*$' \
+            | sed 's/[[:space:]]*$//'
+        )
+
+        if [[ ${#BLOCKED[@]} -eq 0 ]]; then
+          echo "No blocked paths configured — skipping check."
+          exit 0
+        fi
+
+        echo "Blocked path patterns (${#BLOCKED[@]}):"
+        printf '  • %s\n' "${BLOCKED[@]}"
+        echo ""
+
+        # Fetch every changed filename in this PR via the GitHub REST API.
+        # --paginate handles PRs with more than 30 changed files.
+        mapfile -t CHANGED_FILES < <(
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate \
+            --jq '.[].filename'
+        )
+
+        echo "Scanning ${#CHANGED_FILES[@]} changed file(s)..."
+
+        VIOLATIONS=()
+        for file in "${CHANGED_FILES[@]}"; do
+          for pattern in "${BLOCKED[@]}"; do
+            if [[ "$file" == "$pattern" ]]; then
+              # Exact file match
+              VIOLATIONS+=("$file (matched: '$pattern')")
+              break
+            elif [[ "${pattern: -1}" == "/" && "$file" == "${pattern}"* ]]; then
+              # Directory prefix match (pattern ends with /)
+              VIOLATIONS+=("$file (matched directory: '$pattern')")
+              break
+            fi
+          done
+        done
+
+        if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+          echo ""
+          echo "::error::This pull request modifies files in directories that must not appear in the public repository."
+          echo ""
+          echo "Blocked files detected:"
+          for v in "${VIOLATIONS[@]}"; do
+            filename="${v%% (*}"
+            echo "  ✗ $v"
+            echo "::error file=${filename}::File is in a blocked directory and must not be committed to this public repository."
+          done
+          echo ""
+          echo "The following path patterns are restricted in this repository:"
+          printf '  • %s\n' "${BLOCKED[@]}"
+          echo ""
+          echo "These paths contain internal tooling, development plans, or generated"
+          echo "artifacts that are not intended to be publicly visible."
+          echo ""
+          echo "Please remove these files from your pull request before re-requesting review."
+          echo "If you believe this restriction is incorrect, open an issue or contact"
+          echo "the repository maintainers."
+          exit 1
+        fi
+
+        echo "✓ All ${#CHANGED_FILES[@]} file(s) passed the sensitive-path check."


### PR DESCRIPTION
## Summary

Adds the `block-sensitive-paths` reusable composite action to `cascadeguard-actions`.

This action rejects PRs that touch private/internal directories (`.ai/`, `docs/plans/`, `artifacts/`) that must not appear in public repositories.

## Usage

```yaml
- uses: cascadeguard/cascadeguard-actions/block-sensitive-paths@main
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

## Features

- Configurable `blocked-paths` input (newline-separated; trailing `/` = directory prefix match)
- Fetches changed files via paginated GitHub REST API
- Emits per-file `::error::` annotations in the PR diff
- Zero external dependencies (bash + gh CLI)

## Test plan

- [ ] CI passes in this repo
- [ ] OSI `pr-path-guard.yaml` updated to reference this action (see companion OSI PR)
- [ ] Branch protection: add `Block sensitive paths` as required status check in consuming repos after merge

## References

- Paperclip: CAS-169
- Companion OSI PR: updates `pr-path-guard.yaml` to reference this action

Generated with Claude Code