### PR TITLE
feat(CAS-94): add setup-grype and setup-syft composite actions

### DIFF
--- a/setup-grype/action.yml
+++ b/setup-grype/action.yml
@@ -1,0 +1,83 @@
+name: 'Setup Grype'
+description: 'Install Anchore Grype vulnerability scanner at a pinned version'
+author: 'CascadeGuard'
+branding:
+  icon: 'shield'
+  color: 'red'
+
+inputs:
+  version:
+    description: 'Grype version to install (e.g. v0.110.0). Defaults to latest stable.'
+    required: false
+    default: 'latest'
+  install-dir:
+    description: 'Directory to install the grype binary into.'
+    required: false
+    default: '/usr/local/bin'
+  verify-checksum:
+    description: 'Verify the downloaded binary checksum using cosign. Requires cosign to be installed.'
+    required: false
+    default: 'false'
+
+outputs:
+  version:
+    description: 'The installed Grype version string (e.g. v0.110.0).'
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Grype
+      id: install
+      shell: bash
+      env:
+        GRYPE_VERSION: ${{ inputs.version }}
+        INSTALL_DIR: ${{ inputs.install-dir }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$GRYPE_VERSION" == "latest" ]]; then
+          RESOLVED=$(curl -sSfL \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/anchore/grype/releases/latest \
+            | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+          echo "Resolved latest Grype version: ${RESOLVED}"
+          GRYPE_VERSION="${RESOLVED}"
+        fi
+
+        echo "Installing Grype ${GRYPE_VERSION} to ${INSTALL_DIR}..."
+        curl -sSfL \
+          "https://raw.githubusercontent.com/anchore/grype/${GRYPE_VERSION}/install.sh" \
+          | sh -s -- -b "${INSTALL_DIR}" "${GRYPE_VERSION}"
+
+        INSTALLED=$(grype version --output json 2>/dev/null | grep '"version"' | head -1 \
+          | sed 's/.*"version": *"\([^"]*\)".*/\1/' || grype version 2>&1 | head -1)
+        echo "Installed Grype: ${INSTALLED}"
+        echo "version=${GRYPE_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Verify Grype checksum with cosign
+      if: inputs.verify-checksum == 'true'
+      shell: bash
+      env:
+        GRYPE_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        # Grype releases are signed with cosign keyless via Sigstore.
+        # Checksums file and its cosign bundle are published alongside each release.
+        BASE_URL="https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}"
+        CHECKSUMS_FILE="grype_${GRYPE_VERSION#v}_checksums.txt"
+
+        curl -sSfL "${BASE_URL}/${CHECKSUMS_FILE}" -o "/tmp/${CHECKSUMS_FILE}"
+        curl -sSfL "${BASE_URL}/${CHECKSUMS_FILE}.pem" -o "/tmp/${CHECKSUMS_FILE}.pem"
+        curl -sSfL "${BASE_URL}/${CHECKSUMS_FILE}.sig" -o "/tmp/${CHECKSUMS_FILE}.sig"
+
+        cosign verify-blob \
+          --certificate "/tmp/${CHECKSUMS_FILE}.pem" \
+          --signature "/tmp/${CHECKSUMS_FILE}.sig" \
+          --certificate-identity-regexp "https://github.com/anchore/grype/.*" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          "/tmp/${CHECKSUMS_FILE}"
+
+        echo "::notice::Grype ${GRYPE_VERSION} checksums verified via cosign."
+        rm -f "/tmp/${CHECKSUMS_FILE}" "/tmp/${CHECKSUMS_FILE}.pem" "/tmp/${CHECKSUMS_FILE}.sig"

--- a/setup-syft/action.yml
+++ b/setup-syft/action.yml
@@ -1,0 +1,83 @@
+name: 'Setup Syft'
+description: 'Install Anchore Syft SBOM generator at a pinned version'
+author: 'CascadeGuard'
+branding:
+  icon: 'package'
+  color: 'blue'
+
+inputs:
+  version:
+    description: 'Syft version to install (e.g. v1.42.3). Defaults to latest stable.'
+    required: false
+    default: 'latest'
+  install-dir:
+    description: 'Directory to install the syft binary into.'
+    required: false
+    default: '/usr/local/bin'
+  verify-checksum:
+    description: 'Verify the downloaded binary checksum using cosign. Requires cosign to be installed.'
+    required: false
+    default: 'false'
+
+outputs:
+  version:
+    description: 'The installed Syft version string (e.g. v1.42.3).'
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Syft
+      id: install
+      shell: bash
+      env:
+        SYFT_VERSION: ${{ inputs.version }}
+        INSTALL_DIR: ${{ inputs.install-dir }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$SYFT_VERSION" == "latest" ]]; then
+          RESOLVED=$(curl -sSfL \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/anchore/syft/releases/latest \
+            | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+          echo "Resolved latest Syft version: ${RESOLVED}"
+          SYFT_VERSION="${RESOLVED}"
+        fi
+
+        echo "Installing Syft ${SYFT_VERSION} to ${INSTALL_DIR}..."
+        curl -sSfL \
+          "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh" \
+          | sh -s -- -b "${INSTALL_DIR}" "${SYFT_VERSION}"
+
+        INSTALLED=$(syft version --output json 2>/dev/null | grep '"version"' | head -1 \
+          | sed 's/.*"version": *"\([^"]*\)".*/\1/' || syft version 2>&1 | head -1)
+        echo "Installed Syft: ${INSTALLED}"
+        echo "version=${SYFT_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Verify Syft checksum with cosign
+      if: inputs.verify-checksum == 'true'
+      shell: bash
+      env:
+        SYFT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        # Syft releases are signed with cosign keyless via Sigstore.
+        # Checksums file and its cosign bundle are published alongside each release.
+        BASE_URL="https://github.com/anchore/syft/releases/download/${SYFT_VERSION}"
+        CHECKSUMS_FILE="syft_${SYFT_VERSION#v}_checksums.txt"
+
+        curl -sSfL "${BASE_URL}/${CHECKSUMS_FILE}" -o "/tmp/${CHECKSUMS_FILE}"
+        curl -sSfL "${BASE_URL}/${CHECKSUMS_FILE}.pem" -o "/tmp/${CHECKSUMS_FILE}.pem"
+        curl -sSfL "${BASE_URL}/${CHECKSUMS_FILE}.sig" -o "/tmp/${CHECKSUMS_FILE}.sig"
+
+        cosign verify-blob \
+          --certificate "/tmp/${CHECKSUMS_FILE}.pem" \
+          --signature "/tmp/${CHECKSUMS_FILE}.sig" \
+          --certificate-identity-regexp "https://github.com/anchore/syft/.*" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          "/tmp/${CHECKSUMS_FILE}"
+
+        echo "::notice::Syft ${SYFT_VERSION} checksums verified via cosign."
+        rm -f "/tmp/${CHECKSUMS_FILE}" "/tmp/${CHECKSUMS_FILE}.pem" "/tmp/${CHECKSUMS_FILE}.sig"


### PR DESCRIPTION
## Summary

Adds two new reusable composite actions for installing Grype and Syft — CascadeGuard-owned replacements for `anchore/setup-grype` and `anchore/setup-syft` (which do not exist as public repos).

- **`setup-grype/action.yml`** — installs Grype at a pinned version; resolves `latest` via GitHub API; optionally verifies release checksums via cosign keyless signatures
- **`setup-syft/action.yml`** — same pattern for the Syft SBOM generator

Both actions accept:
- `version` (default: `latest`)
- `install-dir` (default: `/usr/local/bin`)
- `verify-checksum` (default: `false`) — requires cosign to be installed

## Why

CascadeGuard will emit grype/syft install steps in generated CI pipelines for users. Owning the action definition gives us versioning control, consistent pinning, and a trust signal. It also fixes the `build-image.yaml` and `scheduled-scan.yaml` workflows that were installing from unpinned `main`.

## Test plan

- [ ] Verify `setup-grype` installs the specified version to `/usr/local/bin/grype`
- [ ] Verify `setup-syft` installs the specified version to `/usr/local/bin/syft`
- [ ] Verify `version: latest` resolves and installs correctly
- [ ] Verify `verify-checksum: true` passes with cosign installed

## Related

- Paperclip issue: [CAS-94](/CAS/issues/CAS-94)
- [CAS-82](/CAS/issues/CAS-82) — original pinning task that surfaced this gap
- Companion PR in cascadeguard-open-secure-images updates the three CI workflows to use these actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)