### PR TITLE
fix(CAS-376): update scan actions to use renamed CLI commands

### DIFF
--- a/scan-issues/action.yml
+++ b/scan-issues/action.yml
@@ -70,7 +70,7 @@ runs:
           TAG_ARG="--tag ${{ inputs.tag }}"
         fi
 
-        OUTPUT=$(cascadeguard scan-issues \
+        OUTPUT=$(cascadeguard vuln issues \
           "${ARGS[@]}" \
           --image "${{ inputs.image }}" \
           $TAG_ARG \

--- a/scan-report/action.yml
+++ b/scan-report/action.yml
@@ -65,7 +65,7 @@ runs:
 
         mkdir -p "${{ inputs.output-dir }}"
 
-        cascadeguard scan-report \
+        cascadeguard vuln report \
           "${ARGS[@]}" \
           --image "${{ inputs.image }}" \
           --dir "${{ inputs.output-dir }}"


### PR DESCRIPTION
## Summary

- `scan-report/action.yml`: `cascadeguard scan-report` → `cascadeguard vuln report`
- `scan-issues/action.yml`: `cascadeguard scan-issues` → `cascadeguard vuln issues`

The CascadeGuard CLI renamed these subcommands under the `vuln` command group. The composite actions were still calling the old removed commands, causing CI failures in `cascadeguard-open-secure-images` scheduled scans.

Fixes: CAS-376

🤖 Generated with [Claude Code](https://claude.com/claude-code)