### PR TITLE
fix: skip build job when no buildable images in matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      has_images: ${{ steps.matrix.outputs.has_images }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -61,6 +62,7 @@ jobs:
           matrix = json.dumps({'include': include})
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f'matrix={matrix}\n')
+              f.write(f'has_images={"true" if include else "false"}\n')
           print(f'Generated matrix with {len(include)} image(s): {[e["image_name"] for e in include]}')
           PYEOF
         env:
@@ -82,6 +84,7 @@ jobs:
   # ── Per-Image Build Pipeline ─────────────────────────────────────
   build:
     needs: [generate-matrix, validate]
+    if: needs.generate-matrix.outputs.has_images == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}


### PR DESCRIPTION
Empty matrix (no entries with `dockerfile`) caused the build job to fail instead of being skipped. The build-gate then saw `failure` and errored out.

Fix: `generate-matrix` now outputs a `has_images` flag, and the `build` job is gated with `if: has_images == 'true'`. When there are no buildable images, build is cleanly skipped and build-gate passes.