### PR TITLE
fix: matrix supports source.dockerfile and build.enabled:false

### DIFF
--- a/lib/matrix.py
+++ b/lib/matrix.py
@@ -23,6 +23,20 @@ def _active_images(images_data: list[dict]) -> list[dict]:
     return [img for img in images_data if img.get("enabled", True) is not False]
 
 
+def _resolve_dockerfile(img: dict) -> Optional[str]:
+    """Resolve the dockerfile path from source.dockerfile or legacy root field.
+
+    Returns None if no dockerfile is configured or build is disabled.
+    """
+    build_config = img.get("build", {})
+    if isinstance(build_config, dict) and build_config.get("enabled") is False:
+        return None
+    source = img.get("source", {})
+    if isinstance(source, dict):
+        return source.get("dockerfile") or img.get("dockerfile")
+    return img.get("dockerfile")
+
+
 def generate_scan_matrix(
     images_data: list[dict],
     image_filter: str = "",
@@ -133,7 +147,7 @@ def generate_build_matrix(
     include = []
 
     for img in active:
-        dockerfile = img.get("dockerfile")
+        dockerfile = _resolve_dockerfile(img)
         if not dockerfile:
             continue
 

--- a/lib/tests/test_matrix.py
+++ b/lib/tests/test_matrix.py
@@ -157,3 +157,49 @@ class TestBuildMatrixOutputShape:
         images = [{"name": "x", "image": "x", "tag": "latest"}]
         result = generate_build_matrix(images)
         assert result["has_images"] is False
+
+
+class TestSourceDockerfile:
+    """Dockerfile resolved from source.dockerfile."""
+
+    def test_source_dockerfile_used(self):
+        images = [{"name": "x", "image": "x", "tag": "latest",
+                   "source": {"dockerfile": "images/x/Dockerfile"}}]
+        result = generate_build_matrix(images)
+        assert result["has_images"] is True
+        assert result["include"][0]["image_path"] == "x"
+
+    def test_root_dockerfile_fallback(self):
+        images = [{"name": "x", "image": "x", "tag": "latest",
+                   "dockerfile": "images/x/Dockerfile"}]
+        result = generate_build_matrix(images)
+        assert result["has_images"] is True
+
+    def test_source_dockerfile_takes_precedence(self):
+        images = [{"name": "x", "image": "x", "tag": "latest",
+                   "dockerfile": "images/old/Dockerfile",
+                   "source": {"dockerfile": "images/new/Dockerfile"}}]
+        result = generate_build_matrix(images)
+        assert result["include"][0]["image_path"] == "new"
+
+
+class TestBuildEnabledFalse:
+    """Images with build.enabled: false are excluded."""
+
+    def test_build_disabled_excluded(self):
+        images = [
+            {"name": "x", "image": "x", "tag": "latest",
+             "source": {"dockerfile": "images/x/Dockerfile"}},
+            {"name": "y", "image": "y", "tag": "latest",
+             "build": {"enabled": False}},
+        ]
+        result = generate_build_matrix(images)
+        assert len(result["include"]) == 1
+        assert result["include"][0]["image_name"] == "x"
+
+    def test_build_enabled_true_included(self):
+        images = [{"name": "x", "image": "x", "tag": "latest",
+                   "build": {"enabled": True},
+                   "source": {"dockerfile": "images/x/Dockerfile"}}]
+        result = generate_build_matrix(images)
+        assert result["has_images"] is True


### PR DESCRIPTION
- `_resolve_dockerfile` helper: prefers `source.dockerfile`, falls back to root `dockerfile`
- `build.enabled: false` images excluded from build matrix
- 5 new tests (33 total)
- Unblocks cascadeguard-data and cascadeguard-exemplar PRs