### PR TITLE
fix: pin CLI SHA in setup-cascadeguard

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,10 +16,10 @@ on:
   workflow_call:
     inputs:
       cascadeguard-version:
-        description: "CascadeGuard CLI version (git ref) to install"
+        description: "CascadeGuard CLI version (git ref or SHA)"
         type: string
         required: false
-        default: "main"
+        default: ""
       image:
         description: "Scope check to a single image name"
         type: string
@@ -57,7 +57,7 @@ jobs:
       - name: Set up CascadeGuard CLI
         uses: cascadeguard/cascadeguard-actions/setup-cascadeguard@main
         with:
-          version: ${{ inputs.cascadeguard-version }}
+          version: ${{ inputs.cascadeguard-version || '' }}
 
       - name: Run cascadeguard images check
         id: check

--- a/setup-cascadeguard/action.yml
+++ b/setup-cascadeguard/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   version:
-    description: 'CascadeGuard version — a git ref (branch, tag, SHA) for source install, or "latest" for the newest release.'
+    description: 'CascadeGuard version — a git ref (branch, tag, SHA).'
     required: false
-    default: 'main'
+    default: '4f50b52b938d3882b4a6eae1dcd38507d8a82ee7'  # cascadeguard/cascadeguard@main
   python-version:
     description: 'Python version to use.'
     required: false


### PR DESCRIPTION
Pin cascadeguard CLI to `4f50b52` (includes source.dockerfile and build.enabled:false fixes). Add `--no-cache-dir` to pip install.

Once merged, all repos referencing `setup-cascadeguard@main` will get the correct CLI version. Then we pin the actions SHA in all downstream repos.