### PR TITLE
fix: use full image_path, support source.dockerfile everywhere

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
     inputs:
       image_path:
-        description: "Path under images/ (e.g., python/3.12)"
+        description: "Directory containing the Dockerfile (e.g., images/python/3.12)"
         required: true
         type: string
       image_name:
@@ -64,14 +64,14 @@ jobs:
       - name: Copy shared hardening scripts into build context
         run: |
           if [ -d shared ]; then
-            cp -r shared images/${{ inputs.image_path }}/shared
+            cp -r shared ${{ inputs.image_path }}/shared
           fi
 
       - name: Build image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
-          context: images/${{ inputs.image_path }}
-          file: images/${{ inputs.image_path }}/Dockerfile
+          context: ${{ inputs.image_path }}
+          file: ${{ inputs.image_path }}/Dockerfile
           push: false
           load: true
           tags: ${{ steps.meta.outputs.full_image }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Run container structure tests
         run: |
-          TEST_CONFIG="images/${{ inputs.image_path }}/test/structure.yaml"
+          TEST_CONFIG="${{ inputs.image_path }}/test/structure.yaml"
           if [ -f "$TEST_CONFIG" ]; then
             container-structure-test test \
               --image "${{ steps.meta.outputs.full_image }}" \
@@ -218,4 +218,4 @@ jobs:
       # ── Cleanup ──────────────────────────────────────────────────
       - name: Clean up build context
         if: always()
-        run: rm -rf images/${{ inputs.image_path }}/shared
+        run: rm -rf ${{ inputs.image_path }}/shared

--- a/lib/matrix.py
+++ b/lib/matrix.py
@@ -10,12 +10,13 @@ from typing import List, Optional
 
 
 def derive_image_path(dockerfile: str) -> str:
-    """Extract the path between the first and last segments.
+    """Extract the directory containing the Dockerfile.
 
-    Example: "images/python/3.12/Dockerfile" -> "python/3.12"
+    Example: "images/python/3.12/Dockerfile" -> "images/python/3.12"
+             "local/seed/Dockerfile"          -> "local/seed"
     """
     parts = dockerfile.split("/")
-    return "/".join(parts[1:-1])
+    return "/".join(parts[:-1])
 
 
 def _active_images(images_data: list[dict]) -> list[dict]:

--- a/lib/resolve.py
+++ b/lib/resolve.py
@@ -7,12 +7,13 @@ the resolved path, name, tag, and whether it was found.
 
 
 def derive_image_path(dockerfile: str) -> str:
-    """Extract the path between 'images/' and '/Dockerfile'.
+    """Extract the directory containing the Dockerfile.
 
-    Example: "images/python/3.12/Dockerfile" -> "python/3.12"
+    Example: "images/python/3.12/Dockerfile" -> "images/python/3.12"
+             "local/seed/Dockerfile"          -> "local/seed"
     """
     parts = dockerfile.split("/")
-    return "/".join(parts[1:-1])
+    return "/".join(parts[:-1])
 
 
 def resolve_image(
@@ -34,7 +35,11 @@ def resolve_image(
         if not img.get("enabled", True):
             continue
         if img.get("image") == image_name:
-            image_path = derive_image_path(img["dockerfile"])
+            source = img.get("source", {})
+            dockerfile = source.get("dockerfile") or img.get("dockerfile") if isinstance(source, dict) else img.get("dockerfile")
+            if not dockerfile:
+                continue
+            image_path = derive_image_path(dockerfile)
             tag = image_tag_override if image_tag_override else img["tag"]
             return {
                 "image_path": image_path,

--- a/lib/tests/test_matrix.py
+++ b/lib/tests/test_matrix.py
@@ -143,9 +143,9 @@ class TestBuildMatrixOutputShape:
     def test_image_path_derived_correctly(self):
         result = generate_build_matrix(IMAGES)
         by_name = {e["image_name"]: e for e in result["include"]}
-        assert by_name["nginx"]["image_path"] == "nginx"
-        assert by_name["python"]["image_path"] == "python/3.12"
-        assert by_name["alpine"]["image_path"] == "alpine"
+        assert by_name["nginx"]["image_path"] == "images/nginx"
+        assert by_name["python"]["image_path"] == "images/python/3.12"
+        assert by_name["alpine"]["image_path"] == "images/alpine"
 
     def test_tag_is_string(self):
         images = [{"name": "x", "image": "x", "tag": 3.20,
@@ -167,7 +167,7 @@ class TestSourceDockerfile:
                    "source": {"dockerfile": "images/x/Dockerfile"}}]
         result = generate_build_matrix(images)
         assert result["has_images"] is True
-        assert result["include"][0]["image_path"] == "x"
+        assert result["include"][0]["image_path"] == "images/x"
 
     def test_root_dockerfile_fallback(self):
         images = [{"name": "x", "image": "x", "tag": "latest",
@@ -180,7 +180,7 @@ class TestSourceDockerfile:
                    "dockerfile": "images/old/Dockerfile",
                    "source": {"dockerfile": "images/new/Dockerfile"}}]
         result = generate_build_matrix(images)
-        assert result["include"][0]["image_path"] == "new"
+        assert result["include"][0]["image_path"] == "images/new"
 
 
 class TestBuildEnabledFalse:

--- a/lib/tests/test_resolve.py
+++ b/lib/tests/test_resolve.py
@@ -10,30 +10,33 @@ from resolve import resolve_image, derive_image_path
 
 IMAGES = [
     {"name": "nginx", "image": "nginx", "tag": "stable-alpine-slim",
-     "dockerfile": "images/nginx/Dockerfile"},
+     "source": {"dockerfile": "images/nginx/Dockerfile"}},
     {"name": "python", "image": "python", "tag": "3.12-slim",
-     "dockerfile": "images/python/3.12/Dockerfile"},
+     "source": {"dockerfile": "images/python/3.12/Dockerfile"}},
     {"name": "disabled", "image": "disabled", "tag": "latest",
-     "dockerfile": "images/disabled/Dockerfile", "enabled": False},
+     "source": {"dockerfile": "images/disabled/Dockerfile"}, "enabled": False},
 ]
 
 
 class TestDeriveImagePath:
     def test_simple(self):
-        assert derive_image_path("images/nginx/Dockerfile") == "nginx"
+        assert derive_image_path("images/nginx/Dockerfile") == "images/nginx"
 
     def test_nested(self):
-        assert derive_image_path("images/python/3.12/Dockerfile") == "python/3.12"
+        assert derive_image_path("images/python/3.12/Dockerfile") == "images/python/3.12"
 
     def test_deep(self):
-        assert derive_image_path("images/a/b/c/Dockerfile") == "a/b/c"
+        assert derive_image_path("images/a/b/c/Dockerfile") == "images/a/b/c"
+
+    def test_local_dir(self):
+        assert derive_image_path("local/seed/Dockerfile") == "local/seed"
 
 
 class TestResolveImage:
     def test_found(self):
         result = resolve_image(IMAGES, "nginx")
         assert result["found"] is True
-        assert result["image_path"] == "nginx"
+        assert result["image_path"] == "images/nginx"
         assert result["image_tag"] == "stable-alpine-slim"
 
     def test_tag_override(self):
@@ -50,4 +53,4 @@ class TestResolveImage:
 
     def test_nested_path(self):
         result = resolve_image(IMAGES, "python")
-        assert result["image_path"] == "python/3.12"
+        assert result["image_path"] == "images/python/3.12"


### PR DESCRIPTION
- `build-image.yaml`: uses `image_path` as full directory path (no `images/` prefix hardcoded)
- `derive_image_path`: returns full directory (`images/nginx` not `nginx`)
- `resolve.py`: supports `source.dockerfile`
- 34 tests passing

This allows repos to use any directory structure (`images/`, `local/`, etc.).