### PR TITLE
chore: bump CLI SHA (backfill metadata)

### DIFF
--- a/setup-cascadeguard/action.yml
+++ b/setup-cascadeguard/action.yml
@@ -9,7 +9,7 @@ inputs:
   version:
     description: 'CascadeGuard version — a git ref (branch, tag, SHA).'
     required: false
-    default: '85d11732ebf1f0b2ecbdc5d491c5d386defcef93'  # cascadeguard/cascadeguard@main
+    default: 'a2ae67d405ea9d4c910c12b232d1d9cf5ebdca15'  # cascadeguard/cascadeguard@main
   python-version:
     description: 'Python version to use.'
     required: false


### PR DESCRIPTION
Includes backfill of publishedAt/platforms on existing state files (#92).