### PR TITLE
fix: pass Docker Hub credentials to check CLI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -56,6 +56,8 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           ARGS=(--format "${{ inputs.format }}")
           if [ -n "${{ inputs.image }}" ]; then

--- a/setup-cascadeguard/action.yml
+++ b/setup-cascadeguard/action.yml
@@ -9,7 +9,7 @@ inputs:
   version:
     description: 'CascadeGuard version — a git ref (branch, tag, SHA).'
     required: false
-    default: 'ebde5346348899b098810ee8c14aa2e1f82dd881'  # cascadeguard/cascadeguard@main
+    default: 'f6bec7375eb54896b0c43fb053ee60942db2f136'  # cascadeguard/cascadeguard@main
   python-version:
     description: 'Python version to use.'
     required: false


### PR DESCRIPTION
Forwards DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to the CLI for authenticated tag API requests.