### PR TITLE
fix(setup): install pyyaml before reading .cascadeguard.yaml

### DIFF
--- a/setup-cascadeguard/action.yml
+++ b/setup-cascadeguard/action.yml
@@ -43,6 +43,7 @@ runs:
         VERSION="${CG_VERSION_INPUT}"
 
         if [ -z "$VERSION" ] && [ -f .cascadeguard.yaml ]; then
+          pip install --quiet pyyaml
           VERSION=$(python3 -c "
         import yaml, sys
         try:


### PR DESCRIPTION
The version reader in `setup-cascadeguard` uses `import yaml` but PyYAML isn't available on a fresh `actions/setup-python`. This caused `.cascadeguard.yaml` `cli.version` pins to be silently ignored, always falling back to `DEFAULT_VERSION`.

Fix: `pip install --quiet pyyaml` before the Python snippet runs.

Needed by cascadeguard-data to pick up the CLI fix from [cascadeguard#103](https://github.com/cascadeguard/cascadeguard/pull/103).