### PR TITLE
feat(CAS-599): add scan-cve action and CVE scan step to check workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -78,11 +78,40 @@ jobs:
             echo "has-drift=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Scan CVEs
+        id: cve-scan
+        uses: ./scan-cve
+        with:
+          images-yaml: images.yaml
+          state-dir: .cascadeguard
+
+      - name: Commit CVE scan results
+        if: steps.cve-scan.outputs.scanned-count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "cascadeguard[bot]"
+          git config user.email "cascadeguard[bot]@users.noreply.github.com"
+          git add .cascadeguard/
+          if git diff --cached --quiet; then
+            echo "No CVE state changes to commit."
+          else
+            SCAN_DATE=$(date -u +%Y-%m-%d)
+            git commit -m "chore(cve): update CVE scan results — ${SCAN_DATE} [skip ci]
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+            git push origin main
+          fi
+
       - name: Summary
         if: always()
         run: |
           if [ "${{ steps.check.outputs.has-drift }}" = "true" ]; then
             echo "::warning::Image drift detected — state files updated"
-          else
-            echo "All images up to date"
           fi
+          if [ "${{ steps.cve-scan.outputs.has-findings }}" = "true" ]; then
+            echo "::warning::Critical/High CVEs found — check state files for details"
+          fi
+          SCANNED="${{ steps.cve-scan.outputs.scanned-count }}"
+          SKIPPED="${{ steps.cve-scan.outputs.skipped-count }}"
+          echo "CVE scan: ${SCANNED:-0} scanned, ${SKIPPED:-0} skipped"

--- a/scan-cve/action.yml
+++ b/scan-cve/action.yml
@@ -1,0 +1,260 @@
+name: 'CascadeGuard CVE Scan'
+description: >
+  Scan upstream container tags with Grype and write CVE summary YAML into
+  state files alongside existing CascadeGuard state.  Skips digests already
+  scanned (sha-dedup) and honours the scannable flag set by the classify-tags
+  hook.  Falls back to latest_stable_tags from images.yaml when the scannable
+  field is absent (repos without the classify-tags hook).
+author: 'CascadeGuard'
+branding:
+  icon: 'shield'
+  color: 'orange'
+
+inputs:
+  images-yaml:
+    description: 'Path to images.yaml (default: images.yaml)'
+    required: false
+    default: 'images.yaml'
+  state-dir:
+    description: 'CascadeGuard state directory (default: .cascadeguard)'
+    required: false
+    default: '.cascadeguard'
+  grype-version:
+    description: 'Grype version to install, e.g. v0.110.0 (default: latest)'
+    required: false
+    default: 'latest'
+  max-scans:
+    description: 'Maximum number of Grype scans per run (default: 30)'
+    required: false
+    default: '30'
+
+outputs:
+  scanned-count:
+    description: 'Number of tags scanned this run'
+    value: ${{ steps.scan.outputs.scanned-count }}
+  skipped-count:
+    description: 'Number of tags skipped (already scanned or not scannable)'
+    value: ${{ steps.scan.outputs.skipped-count }}
+  has-findings:
+    description: "'true' if any critical or high CVEs were found"
+    value: ${{ steps.scan.outputs.has-findings }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Grype
+      shell: bash
+      env:
+        GRYPE_VERSION: ${{ inputs.grype-version }}
+      run: |
+        set -euo pipefail
+        if [[ "${GRYPE_VERSION}" == "latest" ]]; then
+          GRYPE_VERSION=$(curl -sSfL \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/anchore/grype/releases/latest \
+            | grep '"tag_name"' | head -1 \
+            | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+          echo "Resolved latest Grype: ${GRYPE_VERSION}"
+        fi
+        curl -sSfL \
+          "https://raw.githubusercontent.com/anchore/grype/${GRYPE_VERSION}/install.sh" \
+          | sh -s -- -b /usr/local/bin "${GRYPE_VERSION}"
+        grype version
+
+    - name: Scan CVEs for scannable tags
+      id: scan
+      shell: bash
+      env:
+        CG_IMAGES_YAML: ${{ inputs.images-yaml }}
+        CG_STATE_DIR: ${{ inputs.state-dir }}
+        CG_MAX_SCANS: ${{ inputs.max-scans }}
+      run: |
+        python3 - << 'PYEOF'
+        import json
+        import os
+        import subprocess
+        import sys
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        import yaml
+
+        images_yaml_path = Path(os.environ.get("CG_IMAGES_YAML", "images.yaml"))
+        state_dir = Path(os.environ.get("CG_STATE_DIR", ".cascadeguard"))
+        max_scans = int(os.environ.get("CG_MAX_SCANS", "30"))
+        images_dir = state_dir / "images"
+
+        if not images_yaml_path.exists():
+            print(f"No images.yaml at {images_yaml_path}, nothing to scan.")
+            sys.exit(0)
+
+        if not images_dir.exists():
+            print(f"No state dir at {images_dir}, nothing to scan.")
+            sys.exit(0)
+
+        with open(images_yaml_path) as f:
+            images_list = yaml.safe_load(f) or []
+
+        images_meta = {
+            img["name"]: img
+            for img in images_list
+            if isinstance(img, dict) and img.get("name")
+        }
+
+        SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "negligible": 0}
+
+        scanned = 0
+        skipped = 0
+        errors = 0
+        has_critical_high = False
+
+        for state_file in sorted(images_dir.glob("*.yaml")):
+            if scanned >= max_scans:
+                break
+
+            with open(state_file) as f:
+                state = yaml.safe_load(f) or {}
+
+            name = state.get("name", state_file.stem)
+            img_meta = images_meta.get(name, {})
+
+            registry = state.get("registry") or img_meta.get("registry", "docker.io")
+            namespace = img_meta.get("namespace", "library")
+            image_name = state.get("image") or img_meta.get("image", name)
+            latest_stable = set(str(t) for t in img_meta.get("latest_stable_tags", []))
+
+            upstream_tags = state.get("upstreamTags") or {}
+            if not upstream_tags:
+                continue
+
+            state_modified = False
+
+            for tag_name, tag_data in upstream_tags.items():
+                if scanned >= max_scans:
+                    break
+                if not isinstance(tag_data, dict):
+                    continue
+
+                # Determine scannability: explicit flag wins; else latest_stable_tags fallback
+                scannable = tag_data.get("scannable")
+                if scannable is None:
+                    scannable = tag_name in latest_stable
+                if not scannable:
+                    skipped += 1
+                    continue
+
+                digest = tag_data.get("digest")
+                if not digest:
+                    skipped += 1
+                    continue
+
+                # Sha-dedup: skip if we already scanned this exact digest
+                existing_vuln = tag_data.get("vulnerabilities") or {}
+                if isinstance(existing_vuln, dict) and existing_vuln.get("digest") == digest:
+                    skipped += 1
+                    continue
+
+                # Build Grype target including digest for reproducibility
+                ns = namespace or "library"
+                reg = registry if registry not in ("", "docker.io") else "docker.io"
+                target = f"{reg}/{ns}/{image_name}:{tag_name}@{digest}"
+
+                print(f"  Scanning {name}:{tag_name} ({digest[:16]}...)")
+
+                try:
+                    result = subprocess.run(
+                        ["grype", target, "-o", "json", "--by-cve"],
+                        capture_output=True,
+                        text=True,
+                        timeout=300,
+                    )
+                    # grype exits 0 (clean) or 1 (vulns found); >1 is an error
+                    if result.returncode > 1:
+                        print(
+                            f"  Warning: grype exited {result.returncode} for {target}",
+                            file=sys.stderr,
+                        )
+                        if result.stderr:
+                            print(f"  stderr: {result.stderr[:300]}", file=sys.stderr)
+                        errors += 1
+                        continue
+
+                    grype_data = json.loads(result.stdout)
+                    matches = grype_data.get("matches", [])
+
+                    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "negligible": 0}
+                    findings = []
+
+                    for match in matches:
+                        vuln = match.get("vulnerability", {})
+                        artifact = match.get("artifact", {})
+                        severity = vuln.get("severity", "Unknown").lower()
+                        if severity in counts:
+                            counts[severity] += 1
+                        fix_vers = vuln.get("fix", {}).get("versions", [])
+                        fixed_in = fix_vers[0].get("version") if fix_vers else None
+                        findings.append({
+                            "cve": vuln.get("id", "UNKNOWN"),
+                            "severity": severity,
+                            "package": artifact.get("name", ""),
+                            "version": artifact.get("version", ""),
+                            "fixedIn": fixed_in,
+                        })
+
+                    # Sort: critical first, then by CVE ID
+                    findings.sort(
+                        key=lambda x: (-SEVERITY_RANK.get(x["severity"], -1), x["cve"])
+                    )
+
+                    if counts["critical"] > 0 or counts["high"] > 0:
+                        has_critical_high = True
+
+                    tag_data["vulnerabilities"] = {
+                        "scannedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "scanner": "grype",
+                        "digest": digest,
+                        "counts": counts,
+                        "findings": findings,
+                    }
+                    state_modified = True
+                    scanned += 1
+
+                    sev_summary = ", ".join(
+                        f"{counts[k]} {k}"
+                        for k in ("critical", "high", "medium", "low")
+                        if counts[k] > 0
+                    ) or "clean"
+                    print(f"  {name}:{tag_name}: {sev_summary}")
+
+                except subprocess.TimeoutExpired:
+                    print(f"  Warning: grype timed out for {target}", file=sys.stderr)
+                    errors += 1
+                except (json.JSONDecodeError, KeyError) as exc:
+                    print(f"  Warning: failed to parse grype output for {target}: {exc}", file=sys.stderr)
+                    errors += 1
+
+            if state_modified:
+                with open(state_file, "w") as f:
+                    f.write("# Auto-generated by CascadeGuard\n")
+                    yaml.dump(state, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+        print(f"\nCVE scan: {scanned} scanned, {skipped} skipped, {errors} errors")
+
+        with open("/tmp/cg-cve-scanned", "w") as f:
+            f.write(str(scanned))
+        with open("/tmp/cg-cve-skipped", "w") as f:
+            f.write(str(skipped))
+        with open("/tmp/cg-cve-has-findings", "w") as f:
+            f.write("true" if has_critical_high else "false")
+
+        if errors > 0 and scanned == 0:
+            sys.exit(1)
+        PYEOF
+
+        SCANNED=$(cat /tmp/cg-cve-scanned 2>/dev/null || echo "0")
+        SKIPPED=$(cat /tmp/cg-cve-skipped 2>/dev/null || echo "0")
+        HAS_FINDINGS=$(cat /tmp/cg-cve-has-findings 2>/dev/null || echo "false")
+        echo "scanned-count=${SCANNED}" >> "$GITHUB_OUTPUT"
+        echo "skipped-count=${SKIPPED}" >> "$GITHUB_OUTPUT"
+        echo "has-findings=${HAS_FINDINGS}" >> "$GITHUB_OUTPUT"
+        echo "CVE scan complete — scanned: ${SCANNED}, skipped: ${SKIPPED}"


### PR DESCRIPTION
## Summary

Adds Grype-based CVE scanning to the daily check workflow, covering both `cascadeguard-data` and `cascadeguard-open-secure-images`.

### Changes

- **`scan-cve/action.yml`** — new composite action that:
  - Installs Grype
  - Reads `.cascadeguard/images/` state files after `cg check`
  - Scans tags where `scannable: true` (from classify-tags hook) or in `latest_stable_tags` (fallback for repos without the hook)
  - Sha-dedup: skips digests already scanned (`vulnerabilities.digest == current digest`)
  - Writes CVE summary YAML back into state files
  - Outputs `scanned-count`, `skipped-count`, `has-findings`

- **`.github/workflows/check.yaml`** — adds two steps after `Run cascadeguard images check`:
  1. **Scan CVEs** — calls `./scan-cve` composite action
  2. **Commit CVE scan results** — commits state changes with `[skip ci]`

### CVE summary schema (written per tag)

```yaml
upstreamTags:
  "1.27.5":
    digest: sha256:abc...
    scannable: true
    vulnerabilities:
      scannedAt: "2026-04-27T06:00:00Z"
      scanner: grype
      digest: sha256:abc...  # sha-dedup key
      counts: {critical: 0, high: 2, medium: 5, low: 12, negligible: 0}
      findings:
        - cve: CVE-2026-1234
          severity: high
          package: openssl
          version: 3.0.13
          fixedIn: 3.0.14
```

### Dependency

For `cascadeguard-data`, this depends on [CAS-594](https://github.com/cascadeguard/cascadeguard-data/pull/new/feat/CAS-594-classify-tags-hook) being merged to provide `scannable` flags. For `cascadeguard-open-secure-images`, the `latest_stable_tags` field in `images.yaml` serves as the fallback classification.

### Estimated daily scan volume
- ~11 tags (open-secure-images) + ~5-20 tags (cascadeguard-data) = 15-30 Grype scans/day
- `max-scans` input (default: 30) caps each run

Linked: [CAS-599](/CAS/issues/CAS-599)

🤖 Generated with Claude Code