### PR TITLE
feat(dry-run): comma-sep image splitting, fail-on-drift input

### DIFF
--- a/.github/workflows/check-dry-run.yaml
+++ b/.github/workflows/check-dry-run.yaml
@@ -41,6 +41,14 @@ on:
         type: string
         required: false
         default: "table"
+      force:
+        description: >
+          Bypass the upstream-tag state cache — treat all current tags as unseen
+          so the check always produces output even when state is up to date.
+          Use for fallback/baseline runs where you want verified output, not silence.
+        type: boolean
+        required: false
+        default: false
     outputs:
       has-drift:
         description: "'true' if any enrolled images have updates available"
@@ -71,6 +79,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           CG_FORMAT: ${{ inputs.format }}
           CG_IMAGES: ${{ inputs.images }}
+          CG_FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
 
@@ -78,6 +87,10 @@ jobs:
 
           if [ -n "$CG_IMAGES" ]; then
             ARGS+=(--image "$CG_IMAGES")
+          fi
+
+          if [ "$CG_FORCE" = "true" ]; then
+            ARGS+=(--force-check)
           fi
 
           set +e

--- a/.github/workflows/check-dry-run.yaml
+++ b/.github/workflows/check-dry-run.yaml
@@ -41,14 +41,6 @@ on:
         type: string
         required: false
         default: "table"
-      force:
-        description: >
-          Bypass the upstream-tag state cache — treat all current tags as unseen
-          so the check always produces output even when state is up to date.
-          Use for fallback/baseline runs where you want verified output, not silence.
-        type: boolean
-        required: false
-        default: false
     outputs:
       has-drift:
         description: "'true' if any enrolled images have updates available"
@@ -79,18 +71,17 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           CG_FORMAT: ${{ inputs.format }}
           CG_IMAGES: ${{ inputs.images }}
-          CG_FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
 
           ARGS=(--no-commit --format "$CG_FORMAT")
 
           if [ -n "$CG_IMAGES" ]; then
-            ARGS+=(--image "$CG_IMAGES")
-          fi
-
-          if [ "$CG_FORCE" = "true" ]; then
-            ARGS+=(--force-check)
+            IFS=',' read -ra _IMGS <<< "$CG_IMAGES"
+            for _img in "${_IMGS[@]}"; do
+              _img="${_img// /}"
+              [ -n "$_img" ] && ARGS+=(--image "$_img")
+            done
           fi
 
           set +e

--- a/.github/workflows/check-dry-run.yaml
+++ b/.github/workflows/check-dry-run.yaml
@@ -41,6 +41,13 @@ on:
         type: string
         required: false
         default: "table"
+      fail-on-drift:
+        description: >
+          Whether to fail the job when upstream drift is detected (RC=2).
+          Set to false for baseline/fallback runs where drift is informational only.
+        type: boolean
+        required: false
+        default: true
     outputs:
       has-drift:
         description: "'true' if any enrolled images have updates available"
@@ -71,6 +78,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           CG_FORMAT: ${{ inputs.format }}
           CG_IMAGES: ${{ inputs.images }}
+          CG_FAIL_ON_DRIFT: ${{ inputs.fail-on-drift }}
         run: |
           set -euo pipefail
 
@@ -96,8 +104,12 @@ jobs:
               ;;
             2)
               echo "has-drift=true" >> "$GITHUB_OUTPUT"
-              echo "::error title=CascadeGuard drift detected::One or more images have updates available. Run \`cascadeguard images check\` via the scheduled workflow or locally to apply updates."
-              exit 1
+              if [ "$CG_FAIL_ON_DRIFT" = "false" ]; then
+                echo "::warning title=CascadeGuard drift detected::One or more images have updates available (not failing — baseline run)."
+              else
+                echo "::error title=CascadeGuard drift detected::One or more images have updates available. Run \`cascadeguard images check\` via the scheduled workflow or locally to apply updates."
+                exit 1
+              fi
               ;;
             *)
               echo "has-drift=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Splits comma-separated `images` input in shell → passes multiple `--image <name>` flags to CLI (no CLI change needed)
- Adds `fail-on-drift` boolean input (default: `true`): when `false`, RC=2 emits a `::warning` annotation instead of failing — for baseline/fallback runs where upstream drift is informational

## Context

Required by [cascadeguard-data#39](https://github.com/cascadeguard/cascadeguard-data/pull/39) (CAS-662: scope dry-run to changed images). The data repo uses the fallback path (`nginx,alpine,redis`) when `images.yaml` is unchanged — drift on those images should warn, not block, unrelated PRs.

## Test plan
- [ ] `images: "nginx,alpine,redis"` passes three separate `--image` flags to CLI
- [ ] `fail-on-drift: false` + RC=2 → job passes with `::warning` annotation
- [ ] `fail-on-drift: true` (default) + RC=2 → job fails as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)