### PR TITLE
chore: dependabot sweep 2026-05 (actions CI + setuptools)

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -83,7 +83,7 @@ jobs:
 
       # ── Scanning ─────────────────────────────────────────────────
       - name: Install Grype
-        uses: cascadeguard/cascadeguard-actions/setup-grype@d618b14ba0316b803ea98c1808d5b6392c97d5e1 # CAS-94
+        uses: cascadeguard/cascadeguard-actions/setup-grype@23b32fea1e1f1992faea9e978e9741810bf3ebac # CAS-94
         with:
           version: v0.110.0
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Grype SARIF results
         if: always()
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           sarif_file: grype-results.sarif
           category: grype-${{ inputs.image_name }}
@@ -107,7 +107,7 @@ jobs:
 
       # ── Trivy (secondary scanner) ────────────────────────────────
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
         with:
           image-ref: ${{ steps.meta.outputs.full_image }}
           format: json
@@ -144,7 +144,7 @@ jobs:
 
       # ── SBOM Generation ──────────────────────────────────────────
       - name: Install Syft
-        uses: cascadeguard/cascadeguard-actions/setup-syft@d618b14ba0316b803ea98c1808d5b6392c97d5e1 # CAS-94
+        uses: cascadeguard/cascadeguard-actions/setup-syft@23b32fea1e1f1992faea9e978e9741810bf3ebac # CAS-94
         with:
           version: v1.42.3
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,7 +157,7 @@ jobs:
 
       # ── Scan ────────────────────────────────────────────────────
       - name: Install Grype
-        uses: cascadeguard/cascadeguard-actions/setup-grype@d618b14ba0316b803ea98c1808d5b6392c97d5e1 # CAS-94
+        uses: cascadeguard/cascadeguard-actions/setup-grype@23b32fea1e1f1992faea9e978e9741810bf3ebac # CAS-94
         with:
           version: ${{ inputs.grype-version }}
 
@@ -175,7 +175,7 @@ jobs:
 
       # ── SBOM ────────────────────────────────────────────────────
       - name: Install Syft
-        uses: cascadeguard/cascadeguard-actions/setup-syft@d618b14ba0316b803ea98c1808d5b6392c97d5e1 # CAS-94
+        uses: cascadeguard/cascadeguard-actions/setup-syft@23b32fea1e1f1992faea9e978e9741810bf3ebac # CAS-94
         with:
           version: ${{ inputs.syft-version }}
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,7 +42,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v3.28.5
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v3.28.5
         with:
           sarif_file: scorecard-results.sarif
           wait-for-processing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ python_functions = ["test_*"]
 addopts = "-v --tb=short"
 
 [build-system]
-requires = ["setuptools>=45"]
+requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Dependabot Sweep — May 2026

Rolls up safe Dependabot bumps for CI actions and Python deps.

### Included
- GitHub Actions group bump (3 CI actions, #39)
- `setuptools` >=45 → >=82.0.1 (lower-bound only, #21)

Part of routine [CAS-695](/CAS/issues/CAS-695) weekly Dependabot sweep.